### PR TITLE
Add memory limit with a new version of field name

### DIFF
--- a/etc/che-plugin.yaml
+++ b/etc/che-plugin.yaml
@@ -42,3 +42,4 @@ containers:
    ports:
        - exposedPort: 8080
    memory-limit: "1024M"
+   memoryLimit: "1024M"


### PR DESCRIPTION
Needed for compatibility with the upcoming Che version.
Stays compatible with the previous versions until removal of
field `memory-limit`. It should be removed after several releases
of Che.